### PR TITLE
Update chaosforge subdomain to drl and use https

### DIFF
--- a/bin/help/feedback.hlp
+++ b/bin/help/feedback.hlp
@@ -4,7 +4,7 @@ I await your feedback! Mail me at admin@@chaosforge.org. Tell me what you
 like, what you don't, and submit the bug reports :). The official webpage
 of @rDoomRL@> is
 
-@B  http://doom.chaosforge.org/@>
+@B  https://drl.chaosforge.org/@>
 
 DoomRL has it's own forum, it is quite active, and can be found at
 
@@ -19,7 +19,7 @@ ChaosForge has also it's official Google+, Facebook and Twitter profiles:
 The primary source for DoomRL guides, information and spoilers is the 
 DoomRL Wiki
 
-@B  http://doom.chaosforge.org/wiki/@>
+@B  https://drl.chaosforge.org/wiki/@>
 
 Game Hunter has a great channel full of DoomRL Tutorials on youtube:
 

--- a/bin/lua/main.lua
+++ b/bin/lua/main.lua
@@ -768,7 +768,7 @@ function DoomRL.OnWinGame()
 
                    Congratulations!
            Look further for the next release
-            on http://doom.chaosforge.org/]])
+            on https://drl.chaosforge.org/]])
 	ui.blood_slide()
 	return true
 end
@@ -781,7 +781,7 @@ You are running DoomRL for the first time. I hope you will find this roguelike g
 
 This game is in active development, and as such please be always sure that you have the most recent version, for bugs are fixed, new features appear, and the game becomes better at every iteration. You can find the lastest version on DoomRL website:
 
-@Bhttp://doom.chaosforge.org/@y
+@Bhttps://drl.chaosforge.org/@y
 
 Also, if you enjoy this game, join the forums:
 

--- a/bin/manual.txt
+++ b/bin/manual.txt
@@ -397,7 +397,7 @@ I await your feedback! Mail me at admin@chaosforge.org. Tell me what you
 like, what you don't, and submit the bug reports :). The official webpage
 of DoomRL is
 
-  http://doom.chaosforge.org/
+  https://drl.chaosforge.org/
 
 DoomRL has it's own forum, it is quite active, and can be found at
 
@@ -412,7 +412,7 @@ ChaosForge has also it's official Google+, Facebook and Twitter profiles:
 The primary source for DoomRL guides, information and spoilers is the 
 DoomRL Wiki
 
-  http://doom.chaosforge.org/wiki/
+  https://drl.chaosforge.org/wiki/
 
 Game Hunter has a great channel full of DoomRL Tutorials on youtube:
 

--- a/bin/modules/!readme.txt
+++ b/bin/modules/!readme.txt
@@ -5,4 +5,4 @@ Drop your module wad files here!
 Check out the ChaosForge DoomRL Modding subforum for latest mods, and the DoomRL wiki for more information!
 
 http://forum.chaosforge.org/
-http://doom.chaosforge.org/wiki/
+https://drl.chaosforge.org/wiki/

--- a/makefile.lua
+++ b/makefile.lua
@@ -115,7 +115,7 @@ makefile = {
 			{ name = "DoomRL (console mode)", exe = "doomrl", parameters = "-console" },
 			{ name = "DoomRL Manual", file = "manual.txt" },
 			{ name = "ChaosForge Website", url = "http://www.chaosforge.org/" },
-			{ name = "DoomRL Website", url = "http://doom.chaosforge.org/" },
+			{ name = "DoomRL Website", url = "https://drl.chaosforge.org/" },
 			{ name = "DoomRL Forum", url = "http://forum.chaosforge.org/" },
 		},
 		dmg_size   = 128000,

--- a/src/doomnet.pas
+++ b/src/doomnet.pas
@@ -97,7 +97,7 @@ begin
   if Option_VersionCheck and IsNewer(FStable) then
     if ( MessageBox( 0, 'You''re running an old version of DoomRL, missing out on some awesome features! It is highly recommended for you to upgrade!'#10#10'Do you want to download the newest version now?','DoomRL - new version available!', MB_YESNO or MB_ICONQUESTION ) = IDYES ) then
     begin
-      OpenWebPage('http://doom.chaosforge.org');
+      OpenWebPage('https://drl.chaosforge.org');
       Exit( True );
     end;
   if Option_BetaCheck and IsNewer(FBeta) then


### PR DESCRIPTION
Hi there!

Not sure if you're accepting pull requests, but I noticed the initial screen points to the old subdomain:

<img src="https://cloud.githubusercontent.com/assets/121322/20999912/ac4a7086-bccc-11e6-8731-d26b462b6cd8.png">

It redirects obviously. This just saves a few hops...

```
curl -I http://doom.chaosforge.org/
HTTP/1.1 301 Moved Permanently
Date: Thu, 08 Dec 2016 06:38:36 GMT
Server: Apache/2.2.22 (Debian)
Location: https://doom.chaosforge.org/
Vary: Accept-Encoding
Content-Type: text/html; charset=iso-8859-1
```

```
curl -I https://doom.chaosforge.org/
HTTP/1.1 302 Found
Date: Thu, 08 Dec 2016 06:39:05 GMT
Server: Apache/2.2.22 (Debian)
Location: https://drl.chaosforge.org/
Vary: Accept-Encoding
Content-Type: text/html; charset=iso-8859-1
```

Potential fix attached! `#untested`

Cheers,
  Lee 🍻 