### PR TITLE
Feature/338 starting position bumped 2

### DIFF
--- a/bin/data/drl/levels/carnage.lua
+++ b/bin/data/drl/levels/carnage.lua
@@ -69,9 +69,8 @@ register_level "halls_of_carnage"
 			b:phase()
 		end
 
-		level:player(player_start.x,player_start.y)
-
 		generator.set_permanence( area( 66,9,70,12 ) )
+		level:player(player_start.x,player_start.y)
 		local tick = core.bydiff{ 80, 60, 50, 30, 20 }
 
 		level.data.event = {

--- a/bin/data/drl/levels/carnage.lua
+++ b/bin/data/drl/levels/carnage.lua
@@ -60,13 +60,18 @@ register_level "halls_of_carnage"
 
 		local left   = area( 2,  2, 48, 19 ) 
 		local middle = area( 50, 2, 56, 19 ) 
+		local player_start = coord(8,18)
 
 		level:summon{ "former",   8 + DIFFICULTY,   area = left }
 		level:summon{ "sergeant", 8 + 2*DIFFICULTY, area = left }
 		level:summon{ "lostsoul", 6 + 2*DIFFICULTY, area = middle }
+		for b in level:beings_in_range(player_start,0) do
+			b:phase()
+		end
+
+		level:player(player_start.x,player_start.y)
 
 		generator.set_permanence( area( 66,9,70,12 ) )
-		level:player(8,18)
 		local tick = core.bydiff{ 80, 60, 50, 30, 20 }
 
 		level.data.event = {


### PR DESCRIPTION
Unit testing:
* Updated code to force a monster onto the same space. Monster is phased away. Player stays on standard location.

Note: I feel like the approach is clumsy with regard to lua functions. However the outcome appears correct.