### PR TITLE
Fix mouse auto-reload to check shotcost instead of ammo = 0

### DIFF
--- a/bin/version.txt
+++ b/bin/version.txt
@@ -4,6 +4,7 @@
 [mod] -- GJ#357: Game - buffed berserk powerup duration (300->500)
 [mod] -- GJ#354: Game - increased the falloff of shotguns to compensate for range 1 buff
 [mod] -- GJ#357: Game - powerups refresh instead of stacking
+[fix] -- GJ#360: UI - mouse control now auto-reloads based on shotcost instead of only when ammo is zero
 
 0.10.8
 [new] -- GJ#242: UI - SHIFT-G will now equip items from ground if at all possible (old one goes to inv, or ground if full)

--- a/src/drlbase.pas
+++ b/src/drlbase.pas
@@ -1018,7 +1018,7 @@ begin
     if iButton = VMB_BUTTON_RIGHT then
     begin
       if (IO.MTarget = Player.Position) or
-        ((Player.Inv.Slot[ efWeapon ] <> nil) and (Player.Inv.Slot[ efWeapon ].isRanged) and (not (Player.Inv.Slot[efWeapon].GetFlag(IF_NOAMMO))) and (Player.Inv.Slot[ efWeapon ].Ammo = 0))  then
+        ((Player.Inv.Slot[ efWeapon ] <> nil) and (Player.Inv.Slot[ efWeapon ].isRanged) and (not (Player.Inv.Slot[efWeapon].GetFlag(IF_NOAMMO))) and (Player.Inv.Slot[ efWeapon ].Ammo < Player.Inv.Slot[ efWeapon ].getShotCost))  then
       begin
         if iAlt
           then Exit( HandleCommand( TCommand.Create( COMMAND_ALTRELOAD ) ) )


### PR DESCRIPTION
Fixes GJ#360.\r\n\r\nWhen right-clicking to fire with mouse control, the game would auto-reload only if `ammo == 0`. This failed for weapons with `shotcost > 1` where you could have ammo remaining but not enough for a shot.\r\n\r\n**Change:** `Ammo = 0` → `Ammo < getShotCost` in `HandleMouseEvent` (`drlbase.pas`), consistent with how the rest of the firing logic handles insufficient ammo.